### PR TITLE
resolves #17 - Docker hub rate limiting

### DIFF
--- a/docker_autotag/Dockerfile
+++ b/docker_autotag/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.10-slim-buster
+FROM public.ecr.aws/docker/library/python:3.10-slim
 
 # Set the working directory in the container to /app
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the base image used in the `docker_autotag/Dockerfile` to reference the official Python image from AWS's public ECR registry instead of Docker Hub.

- Docker image update:
  * Changed the `FROM` line in `docker_autotag/Dockerfile` to use `public.ecr.aws/docker/library/python:3.10-slim` instead of `python:3.10-slim-buster`, switching the image source to AWS's public ECR.

## Effect
Helps resolve the rate limiting imposed by Docker Hub for non-pro users by pulling the image from the official AWS ECR.