### PR TITLE
Fix env var passing in RunAltTextGenerationTask

### DIFF
--- a/app.py
+++ b/app.py
@@ -174,7 +174,8 @@ class PDFAccessibility(Stack):
                                       cluster=pdf_remediation_cluster,
                                       task_definition=adobe_autotag_task_def,
                                       assign_public_ip=False,
-                                      
+                                      result_path="$.ecsResult",
+
                                       container_overrides=[tasks.ContainerOverride(
                                        container_definition = adobe_autotag_container_def,
                                           environment=[
@@ -213,11 +214,11 @@ class PDFAccessibility(Stack):
                                           environment=[
                                               tasks.TaskEnvironmentVariable(
                                                   name="S3_BUCKET_NAME",
-                                                  value=sfn.JsonPath.string_at("$.Overrides.ContainerOverrides[0].Environment[0].Value")
+                                                  value=sfn.JsonPath.string_at("$.s3_bucket")
                                               ),
                                               tasks.TaskEnvironmentVariable(
                                                   name="S3_FILE_KEY",
-                                                  value=sfn.JsonPath.string_at("$.Overrides.ContainerOverrides[0].Environment[1].Value")
+                                                  value=sfn.JsonPath.string_at("$.s3_key")
                                               ),
                                               tasks.TaskEnvironmentVariable(
                                                   name="AWS_REGION",


### PR DESCRIPTION
S3_BUCKET_NAME and S3_FILE_KEY were being resolved by indexing into the ECS ContainerOverrides array from the previous task's output. This can cause intermittent failures (~50%) when AWS GuardDuty Runtime Monitoring, which may run as a security requirement in production environments, injects a sidecar container into the ContainerOverrides array at launch time, making the array order unpredictable.

Fixed by:
- Adding result_path='$.ecsResult' to RunAdobeAutotagTask to preserve the original Map iterator input for downstream states
- Updating RunAltTextGenerationTask to reference `$.s3_bucket` and `$.s3_key` directly from the Map iterator input instead of the ECS response array